### PR TITLE
Fix Crash in refetch operation

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -276,7 +276,10 @@ static id RKRefetchedValueInManagedObjectContext(id value, NSManagedObjectContex
                         NSMutableArray *so = NSMutableArray.new;
                         for (id mappingResult in mappingResultsAtRootKey) {
                             if ([mappingResult respondsToSelector:NSSelectorFromString(joinedKeyPath)]) {
-                                [so addObject:[mappingResult valueForKeyPath:joinedKeyPath]];
+                                id object = [mappingResult valueForKeyPath:joinedKeyPath];
+                                if (object) {
+                                    [so addObject:object];
+                                }
                             }
                         }
                         sourceObject = so.copy;


### PR DESCRIPTION
When mapping an array of objects, code was crashing in the case on of the "mapped" nested object was nil.